### PR TITLE
Remove logger.exception from zc.lockfile

### DIFF
--- a/src/zc/lockfile/__init__.py
+++ b/src/zc/lockfile/__init__.py
@@ -87,7 +87,7 @@ class LockFile:
             fp.close()
             if not pid:
                 pid = 'UNKNOWN'
-            logger.exception("Error locking file %s; pid=%s", path, pid)
+            logger.error("Error locking file %s; pid=%s", path, pid)
             raise
 
         self._fp = fp

--- a/src/zc/lockfile/__init__.py
+++ b/src/zc/lockfile/__init__.py
@@ -87,8 +87,7 @@ class LockFile:
             fp.close()
             if not pid:
                 pid = 'UNKNOWN'
-            logger.error("Error locking file %s; pid=%s", path, pid)
-            raise
+            raise LockError("Error locking file '%s'; pid=%s" % (path, pid))
 
         self._fp = fp
         fp.write(" %s\n" % os.getpid())

--- a/src/zc/lockfile/__init__.py
+++ b/src/zc/lockfile/__init__.py
@@ -87,7 +87,7 @@ class LockFile:
             fp.close()
             if not pid:
                 pid = 'UNKNOWN'
-            raise LockError("Error locking file '%s'; pid=%s" % (path, pid))
+            raise LockError("Error locking file %s; pid=%s" % (path, pid))
 
         self._fp = fp
         fp.write(" %s\n" % os.getpid())


### PR DESCRIPTION
Currently the behaviour in zc.lockfile is the log the LockError as an exception.
This causes a lot of small stracktraces in ZODB3 when trying to 'check_blob_cache_size'.
Even if the using product handles the error correctly it still shows up, suggesting a problem.
This seems unwanted behaviour.

So instead of logging it as an exception, I suggest to raise it as a new LockError with the 'pid' added.
And let whoever uses it worry about if they want to log it or not.
