### PR TITLE
made exception logger silent by default in order

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,10 @@ Change History
 - Code and ReST markup cosmetics.
   [alecghica]
 
+- disabled exception logger by default (can be enabled
+  using the ``log_exc`` constructor parameter
+  [ajung]
+
 1.1.0 (2013-02-12)
 ==================
 

--- a/src/zc/lockfile/README.txt
+++ b/src/zc/lockfile/README.txt
@@ -21,7 +21,6 @@ If we try to lock the same name, we'll get a lock error:
 
     >>> for record in handler.records: # doctest: +ELLIPSIS
     ...     print(record.levelname+' '+record.getMessage())
-    ERROR Error locking file lock; pid=...
 
 To release the lock, use it's close method:
 

--- a/src/zc/lockfile/__init__.py
+++ b/src/zc/lockfile/__init__.py
@@ -67,7 +67,7 @@ class LockFile:
 
     _fp = None
 
-    def __init__(self, path):
+    def __init__(self, path, log_exc=False):
         self._path = path
         try:
             # Try to open for writing without truncation:
@@ -87,7 +87,8 @@ class LockFile:
             fp.close()
             if not pid:
                 pid = 'UNKNOWN'
-            logger.exception("Error locking file %s; pid=%s", path, pid)
+            if log_exc:
+                logger.exception("Error locking file %s; pid=%s", path, pid)
             raise
 
         self._fp = fp


### PR DESCRIPTION
do avoid myriades of logger messages as reported here:
https://mail.zope.org/pipermail/zodb-dev/2014-April/015201.html
