### PR TITLE
Be sure to run the tox tests on pypy and pypy3 since it's in the classifiers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 3.2
     - 3.3
     - pypy
+    - pypy3
 install:
     - pip install . --use-mirrors
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py32,py33
+    py26,py27,py32,py33,pypy,pypy3
 
 [testenv]
 commands =


### PR DESCRIPTION
Also add pypy3 to travis.