### PR TITLE
Fixed: unlocking and locking didn't work when a multiprocessing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,9 @@
 Change History
 ***************
 
+- Fixed: unlocking and locking didn't work when a multiprocessing
+  process was running (and presumably other conditions).
+
 1.2.0 (2016-06-09)
 ==================
 

--- a/src/zc/lockfile/__init__.py
+++ b/src/zc/lockfile/__init__.py
@@ -59,9 +59,7 @@ else:
             raise LockError("Couldn't lock %r" % file.name)
 
     def _unlock_file(file):
-        # File is automatically unlocked on close
-        pass
-
+        fcntl.flock(file.fileno(), fcntl.LOCK_UN)
 
 class LazyHostName(object):
     """Avoid importing socket and calling gethostname() unnecessarily"""

--- a/src/zc/lockfile/tests.py
+++ b/src/zc/lockfile/tests.py
@@ -185,6 +185,22 @@ class LockFileLogEntryTestCase(unittest.TestCase):
                      'f.lock', '123/myhostname', '')]
         assert test_logger.log_entries == expected, test_logger.log_entries
 
+    def test_unlock_and_lock_while_multiprocessing_process_running(self):
+        import multiprocessing
+
+        lock = zc.lockfile.LockFile('l')
+        p = multiprocessing.Process(target=time.sleep, args=(1,))
+        p.daemon = True
+        p.start()
+
+        # release and re-acquire should work (obviously)
+        lock.close()
+        lock = zc.lockfile.LockFile('l')
+        self.assertTrue(p.is_alive())
+
+        lock.close()
+        p.join()
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zc/lockfile/tests.py
+++ b/src/zc/lockfile/tests.py
@@ -198,8 +198,8 @@ class LockFileLogEntryTestCase(unittest.TestCase):
         lock.close()
         lock = zc.lockfile.LockFile('l')
         self.assertTrue(p.is_alive())
-        q.put(0)
 
+        q.put(0)
         lock.close()
         p.join()
 

--- a/src/zc/lockfile/tests.py
+++ b/src/zc/lockfile/tests.py
@@ -189,7 +189,8 @@ class LockFileLogEntryTestCase(unittest.TestCase):
         import multiprocessing
 
         lock = zc.lockfile.LockFile('l')
-        p = multiprocessing.Process(target=time.sleep, args=(1,))
+        q = multiprocessing.Queue()
+        p = multiprocessing.Process(target=q.get)
         p.daemon = True
         p.start()
 
@@ -197,6 +198,7 @@ class LockFileLogEntryTestCase(unittest.TestCase):
         lock.close()
         lock = zc.lockfile.LockFile('l')
         self.assertTrue(p.is_alive())
+        q.put(0)
 
         lock.close()
         p.join()


### PR DESCRIPTION
Fixed: unlocking and locking didn't work when a multiprocessing process was running (and presumably other conditions).

The fix was to make an explicit flock unlock call, in addition to
closing the file.

I lost hours debugging a ZEO test failure before I figured this out. :/