### PR TITLE
Claim support for Python 3.4 and 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 python:
     - 2.6
     - 2.7
-    - 3.2
     - 3.3
+    - 3.4
+    - 3.5
     - pypy
     - pypy3
 install:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,15 @@
 Change History
 ***************
 
+1.3.0 (unreleased)
+==================
+
 - Fixed: unlocking and locking didn't work when a multiprocessing
   process was running (and presumably other conditions).
+
+- Claim support for Python 3.4 and 3.5.
+
+- Drop Python 3.2 support because pip no longer supports it.
 
 1.2.0 (2016-06-09)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 
-version = '1.2.0'
+version = '1.3.0.dev0'
 
 import os
 from setuptools import setup, find_packages
@@ -70,8 +70,9 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py32,py33,pypy,pypy3
+    py26,py27,py33,py34,py35,pypy,pypy3
 
 [testenv]
 commands =


### PR DESCRIPTION
+ Drop Python 3.2 support because pip no longer supports it.