### PR TITLE
Stop logging failure to acquire

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Change History
 1.3.0 (unreleased)
 ==================
 
+- Stop logging failure to acquire locks. Clients can do that if they wish.
+
 - Claim support for Python 3.4 and 3.5.
 
 - Drop Python 3.2 support because pip no longer supports it.

--- a/src/zc/lockfile/README.txt
+++ b/src/zc/lockfile/README.txt
@@ -19,9 +19,10 @@ If we try to lock the same name, we'll get a lock error:
     ...     print("Can't lock file")
     Can't lock file
 
+.. We don't log failure to acquire.
+
     >>> for record in handler.records: # doctest: +ELLIPSIS
     ...     print(record.levelname+' '+record.getMessage())
-    ERROR Error locking file lock; pid=...
 
 To release the lock, use it's close method:
 

--- a/src/zc/lockfile/__init__.py
+++ b/src/zc/lockfile/__init__.py
@@ -84,25 +84,9 @@ class LockFile:
             # one will get the the lock and write a pid.
             fp = open(path, 'a+')
 
-        try:
-            _lock_file(fp)
-        except:
-            fp.seek(1)
-            content = fp.read().strip()
-            fp.close()
-            if content_template == '{pid}':
-                # Original exception message format when using the default
-                # lock file template
-                pid = content[:20] if content else 'UNKNOWN'
-                logger.exception("Error locking file %s; pid=%s", path, pid)
-            else:
-                # Include the first 40 characters of lock file contents for
-                # custom lock file templates
-                logger.exception('Error locking file %s; content: "%s%s"',
-                                 path, content[:40],
-                                 '...' if len(content) > 40 else '')
-            raise
+        _lock_file(fp)
 
+        # We got the lock, record info in the file.
         self._fp = fp
         fp.write(" %s\n" % content_template.format(pid=os.getpid(),
                                                    hostname=LazyHostName()))

--- a/src/zc/lockfile/__init__.py
+++ b/src/zc/lockfile/__init__.py
@@ -84,7 +84,11 @@ class LockFile:
             # one will get the the lock and write a pid.
             fp = open(path, 'a+')
 
-        _lock_file(fp)
+        try:
+            _lock_file(fp)
+        except:
+            fp.close()
+            raise
 
         # We got the lock, record info in the file.
         self._fp = fp

--- a/src/zc/lockfile/tests.py
+++ b/src/zc/lockfile/tests.py
@@ -159,6 +159,8 @@ class LockFileLogEntryTestCase(unittest.TestCase):
                 with open('f.lock') as f:
                     self.assertEqual(' 123/myhostname\n', f.read())
 
+                lock.close()
+
     def test_unlock_and_lock_while_multiprocessing_process_running(self):
         import multiprocessing
 

--- a/src/zc/lockfile/tests.py
+++ b/src/zc/lockfile/tests.py
@@ -150,40 +150,14 @@ class LockFileLogEntryTestCase(unittest.TestCase):
         os.chdir(self.here)
         setupstack.rmtree(self.tmp)
 
-    def test_log_entry(self):
+    def test_log_formatting(self):
         # PID and hostname are parsed and logged from lock file on failure
-        test_logger = TestLogger()
-
-        def lock(locked, before_closing):
-            lock = None
-            try:
-                lock = zc.lockfile.LockFile('f.lock',
-                                            content_template='{pid}/{hostname}')
-            except Exception:
-                pass
-            locked.set()
-            before_closing.wait()
-            if lock is not None:
-                lock.close()
-
         with patch('os.getpid', Mock(return_value=123)):
             with patch('socket.gethostname', Mock(return_value='myhostname')):
-                with patch.object(zc.lockfile, 'logger', test_logger):
-                    first_locked = threading.Event()
-                    second_locked = threading.Event()
-                    thread1 = threading.Thread(
-                        target=lock, args=(first_locked, second_locked))
-                    thread2 = threading.Thread(
-                        target=lock, args=(second_locked, second_locked))
-                    thread1.start()
-                    first_locked.wait()
-                    assert not test_logger.log_entries
-                    thread2.start()
-                    thread1.join()
-                    thread2.join()
-        expected = [('Error locking file %s; content: "%s%s"',
-                     'f.lock', '123/myhostname', '')]
-        assert test_logger.log_entries == expected, test_logger.log_entries
+                lock = zc.lockfile.LockFile('f.lock',
+                                            content_template='{pid}/{hostname}')
+                with open('f.lock') as f:
+                    self.assertEqual(' 123/myhostname\n', f.read())
 
     def test_unlock_and_lock_while_multiprocessing_process_running(self):
         import multiprocessing


### PR DESCRIPTION
Notes:

- Replaces #2 and #3 
- This undoes some of the work done in #7 for #6, since we no longer log.