### PR TITLE
Add context manager that associates file with lock

### DIFF
--- a/src/zc/lockfile/README.txt
+++ b/src/zc/lockfile/README.txt
@@ -68,3 +68,22 @@ If you now inspected the lock file, you would see e.g.:
     $ cat lock
      123;myhostname
 
+Context Managers
+================
+
+This module also implements two Context Managers, in addition to the primitives
+discussed above. The first just gets and releases a lock file, with a timeout.
+
+    >>> with zc.lockfile.LockedContext('description', timeout=rough_seconds):
+    ...    do_something()
+
+The lock will always be released when you exit this scope. If timeout is not
+given, it is assumed you wish to wait forever. It should be noted that this
+Context Manager will always add '.lock' to the end of any filename you give it.
+This is to allow for compatibility with its subclass:
+
+    >>> with zc.lockfile.LockedFile('filename.ext', 'r') as f:
+    ...    do_something()
+
+This Context Manager associates a file with a lock. It supports all file modes
+and operations, in addition to the lock templates and timeouts supported above.

--- a/src/zc/lockfile/README.txt
+++ b/src/zc/lockfile/README.txt
@@ -74,16 +74,17 @@ Context Managers
 This module also implements two Context Managers, in addition to the primitives
 discussed above. The first just gets and releases a lock file, with a timeout.
 
+    >>> rough_seconds = 0.7
     >>> with zc.lockfile.LockedContext('description', timeout=rough_seconds):
-    ...    do_something()
+    ...    pass
 
 The lock will always be released when you exit this scope. If timeout is not
 given, it is assumed you wish to wait forever. It should be noted that this
 Context Manager will always add '.lock' to the end of any filename you give it.
 This is to allow for compatibility with its subclass:
 
-    >>> with zc.lockfile.LockedFile('filename.ext', 'r') as f:
-    ...    do_something()
+    >>> with zc.lockfile.LockedFile('filename.ext', 'w') as f:
+    ...    pass
 
 This Context Manager associates a file with a lock. It supports all file modes
 and operations, in addition to the lock templates and timeouts supported above.

--- a/src/zc/lockfile/__init__.py
+++ b/src/zc/lockfile/__init__.py
@@ -146,7 +146,7 @@ class LockedFile(LockedContext):
     """ContextManager version of LockFile, which opens an associated file"""
 
     def __init__(self, name, mode, content_template='{pid}', timeout=None):
-        super(self, LockedFile).__init__(
+        super(LockedFile, self).__init__(
             name,
             content_template=content_template,
             timeout=timeout
@@ -162,4 +162,4 @@ class LockedFile(LockedContext):
         try:
             return self.file.__exit__(*args)
         finally:
-            super(self, LockedFile).__exit__(*args)
+            super(LockedFile, self).__exit__(*args)

--- a/src/zc/lockfile/__init__.py
+++ b/src/zc/lockfile/__init__.py
@@ -142,7 +142,7 @@ class LockedContext(object):
 class LockedFile(LockedContext):
     """ContextManager version of LockFile, which opens an associated file"""
 
-    def __init__(self, name, mode, content_template='{pid}', timeout=None):
+    def __init__(self, name, mode, content_template='{pid}', timeout=float("inf")):
         super(LockedFile, self).__init__(
             name,
             content_template=content_template,

--- a/src/zc/lockfile/tests.py
+++ b/src/zc/lockfile/tests.py
@@ -226,7 +226,7 @@ class LockFileLogEntryTestCase(unittest.TestCase):
 
         with patch('zc.lockfile.LockFile.close', this_counter):
             try:
-                with zc.lockfile.LockedFile('m', 'r') as f:
+                with zc.lockfile.LockedFile('m', 'w') as f:
                     f.write("Test")
                     raise Exception("this is a test")
             except Exception as e:
@@ -235,7 +235,7 @@ class LockFileLogEntryTestCase(unittest.TestCase):
             self.assertEqual(counter.count, 1)
             counter.count = 0
             with open('m', 'r') as f:
-                assertEqual(f.read(), "Test")
+                self.assertEqual(f.read(), "Test")
 
 
 def test_suite():


### PR DESCRIPTION
This has two main benefits:

1. There is less error handling needed on the users' end
2. This has a similar API to Portalocker, enabling people to switch easier