### PR TITLE
Remove explicit dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
     packages = find_packages('src'),
     package_dir = {'': 'src'},
     namespace_packages = ['zc'],
-    install_requires = 'setuptools',
     extras_require=dict(
         test=CONDITIONAL_TEST_REQUIREMENTS + [
             'zope.testing',


### PR DESCRIPTION
This is a rarely stated explicit dependency and is implied in most cases
when using pip and wheels. It creates a problems as this is not
required when installing from a wheel, only when installing from sources

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>