### PR TITLE
a runtime dependency on "setuptools" is not needed anymore

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Change History
 4.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Remove no longer necessary ``setuptools`` runtime dependency.
 
 
 4.0 (2025-09-18)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     keywords="lock",
     url='https://github.com/zopefoundation/zc.lockfile',
     python_requires='>=3.9',
-    setup_requires='setuptools',
     extras_require=dict(
         test=[
             'zope.testing',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     keywords="lock",
     url='https://github.com/zopefoundation/zc.lockfile',
     python_requires='>=3.9',
-    install_requires='setuptools',
+    setup_requires='setuptools',
     extras_require=dict(
         test=[
             'zope.testing',


### PR DESCRIPTION
- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added documentation for my changes.
- [ ] I included a change log entry in my commits.
